### PR TITLE
Ensure MatchLib.Optional doesnt lose Match.Optional special semantics

### DIFF
--- a/match-library.js
+++ b/match-library.js
@@ -9,13 +9,7 @@ var _randomIdRegexp = /^[23456789ABCDEFGHJKLMNPQRSTWXYZabcdefghijkmnopqrstuvwxyz
 MatchLib = {
 
   Optional: function (type) {
-    return Match.Where(function (x) {
-      if (x == null) {
-        return true;
-      }
-      check(x, type);
-      return true;
-    });
+    return Match.Optional(Match.OneOf(undefined, null, type));
   },
 
   NullOr: function (type) {


### PR DESCRIPTION
Meteor special cases Match.Optional so that objects with keys that are marked Match.Optional aren't considered errors.  This code keeps that special behavior for MatchLib.Optional

These should all pass:
check({},  MatchLib.Optional({ foo: Number }) //fails before this commit
check({foo: null },  MatchLib.Optional({ foo: Number })
check({foo: undefined },  MatchLib.Optional({ foo: Number })
check({foo: 1 },  MatchLib.Optional({ foo: Number })

this should fail:
check({foo:'bar' },  MatchLib.Optional({ foo: Number })